### PR TITLE
Update opencl_drivers_blacklist.h to enable neo on Windows

### DIFF
--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -29,13 +29,9 @@ static const gchar *bad_opencl_drivers[] =
   "pocl",
 /*
   Neo was originally blacklisted due to improper cache invalidation, but this has been fixed.
-  During the discussion of that issue in pull request 2033, it was hinted that Neo may be still be
-  problematic on Windows, so keep it blacklisted there for now
-
-  TODO:  Determine if Windows failures were due to the same cache invalidation issue.
+  Per Issue 20104, enabling neo for Windows.
 */
 #if defined _WIN32
-  "neo",
   "d3d12",
 #endif
   NULL


### PR DESCRIPTION
Neo has been working on my windows iGPU laptop without problems. I think we should remove the blacklist. If users have an issue, they should first ensure they have the latest drivers from Intel OR they can disable `Intel` via the `preference` gui. 

https://github.com/darktable-org/darktable/issues/20104